### PR TITLE
[IMP] OD-972, base_menu_visibility_restriction: add strict menu access configuration

### DIFF
--- a/base_menu_visibility_restriction/README.rst
+++ b/base_menu_visibility_restriction/README.rst
@@ -28,9 +28,14 @@ Base Menu Visibility Restriction
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This addon lets you assign "excluded groups" to menu items. If a user
-belongs to a group that is assigned to a menu item as an excluded group,
-the user will not be able to see the menu item.
+This addon lets you apply strict control over which user groups have
+access to which menus. By itself, Odoo let's you restrict menu's to
+specific groups. This addon adds to ways to further limit menu access
+based on user groups:
+
+-  You can block groups to access a specific menu.
+-  You can restrict access for a specific group to all menu items except
+   one or more allowed menus.
 
 **Table of contents**
 
@@ -40,13 +45,25 @@ the user will not be able to see the menu item.
 Usage
 =====
 
-To use this module, you need to:
+To restrict access to a specific menu item to one or more groups, you
+need to:
 
 1. Activate the developer mode
 2. Go to *Settings > Technical > User interface > Menu Items*.
 3. Search for any menu and edit it.
 4. Update "Excluded groups" with one group.
 5. Login with a user of that group, and you won't see such menu.
+
+To allow access of a specific group to only a specific set of menu
+items, you need to:
+
+1. Activate the developer mode
+2. Go to *Settings > Technical > Users & Companies > Groups*.
+3. Search for any group and edit it.
+4. Update "Strict Menu Access" with one or more menus.
+5. The menu path required to access the configured menu will be added
+   automatically.
+6. Login with a user of that group, and you will only see those menus.
 
 You can try with demo data for the menu Apps > App Store and user demo.
 
@@ -71,12 +88,13 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Víctor Martínez
+   -  Víctor Martínez
 
-- Dhara Solanki <dhara.solanki@initos.com>
-- Nedas Žilinskas <nedas.zilinskas@avoin.systems>
+-  Dhara Solanki <dhara.solanki@initos.com>
+-  Nedas Žilinskas <nedas.zilinskas@avoin.systems>
+-  Stefan Rijnhart <stefan@opener.amsterdam>
 
 Maintainers
 -----------

--- a/base_menu_visibility_restriction/__manifest__.py
+++ b/base_menu_visibility_restriction/__manifest__.py
@@ -12,6 +12,6 @@
     "license": "AGPL-3",
     "depends": ["web_tour"],
     "maintainers": ["victoralmau"],
-    "data": ["views/ir_ui_menu.xml"],
+    "data": ["views/ir_ui_menu.xml", "views/res_groups_views.xml"],
     "installable": True,
 }

--- a/base_menu_visibility_restriction/models/__init__.py
+++ b/base_menu_visibility_restriction/models/__init__.py
@@ -1,1 +1,2 @@
 from . import ir_ui_menu
+from . import res_groups

--- a/base_menu_visibility_restriction/models/ir_ui_menu.py
+++ b/base_menu_visibility_restriction/models/ir_ui_menu.py
@@ -15,12 +15,21 @@ class IrUiMenu(models.Model):
     )
 
     @api.model
-    @tools.ormcache("frozenset(self.env.user.groups_id.ids)", "debug")
+    @tools.ormcache(
+        "frozenset(self.env.user.groups_id.ids)",
+        "frozenset(self.env.user.groups_id.included_menu_ids.ids)",
+        "debug",
+    )
     def _visible_menu_ids(self, debug=False):
         """Return the ids of the menu items visible to the user."""
         visible = super()._visible_menu_ids(debug=debug)
         context = {"ir.ui.menu.full_list": True}
         menus = self.with_context(**context).browse(visible)
         groups = self.env.user.groups_id
-        visible = menus - menus.filtered(lambda menu: menu.excluded_group_ids & groups)
-        return set(visible.ids)
+        if groups.included_menu_ids:
+            menus = menus & groups.included_menu_ids
+        elif menus.excluded_group_ids:
+            menus = menus - menus.filtered(
+                lambda menu: menu.excluded_group_ids & groups
+            )
+        return set(menus.ids)

--- a/base_menu_visibility_restriction/models/res_groups.py
+++ b/base_menu_visibility_restriction/models/res_groups.py
@@ -1,0 +1,59 @@
+# Copyright 2025 Opener B.V.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import api, fields, models
+
+
+class ResGroups(models.Model):
+    _inherit = "res.groups"
+
+    included_menu_ids = fields.Many2many(
+        comodel_name="ir.ui.menu",
+        compute="_compute_included_menu_ids",
+        readonly=False,
+        recursive=True,
+        store=True,
+        relation="ir_ui_menu_included_group_rel",
+        column1="gid",
+        column2="menu_id",
+        string="Strict Menu Access",
+        help=(
+            "If set, users in this group have access to *only* this menu. You "
+            "can use it to drastically limit the GUI access that users in this "
+            "group have. If a user is in more than one group with strict menu "
+            "access, they will have access to all the menus linked to all their "
+            "groups."
+        ),
+    )
+
+    @api.depends("included_menu_ids.parent_id")
+    def _compute_included_menu_ids(self):
+        """Add parents when menu is updated"""
+
+        def add_parents(menu, menus):
+            if not menu.parent_id or menu.parent_id in menus:
+                return menus
+            return add_parents(menu.parent_id, menus + menu.parent_id)
+
+        for group in self.filtered("included_menu_ids"):
+            menus = group.included_menu_ids
+            for menu in menus:
+                menus = add_parents(menu, menus)
+            group.included_menu_ids = menus
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Add any parent menus of included menus"""
+        res = super().create(vals_list)
+        res.with_context(included_menu_ids_add_parents=True)
+        return res
+
+    def write(self, vals):
+        """Add any parent menus of included menus"""
+        res = super().write(vals)
+        if "included_menu_ids" in vals and not self.env.context.get(
+            "included_menu_ids_add_parents"
+        ):
+            self.with_context(
+                included_menu_ids_add_parents=True
+            )._compute_included_menu_ids()
+        return res

--- a/base_menu_visibility_restriction/readme/CONTRIBUTORS.md
+++ b/base_menu_visibility_restriction/readme/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
   - Víctor Martínez
 - Dhara Solanki \<<dhara.solanki@initos.com>\>
 - Nedas Žilinskas \<<nedas.zilinskas@avoin.systems>\>
+- Stefan Rijnhart \<<stefan@opener.amsterdam>\>

--- a/base_menu_visibility_restriction/readme/DESCRIPTION.md
+++ b/base_menu_visibility_restriction/readme/DESCRIPTION.md
@@ -1,3 +1,6 @@
-This addon lets you assign "excluded groups" to menu items. If a user
-belongs to a group that is assigned to a menu item as an excluded group,
-the user will not be able to see the menu item.
+This addon lets you apply strict control over which user groups have access to
+which menus. By itself, Odoo let's you restrict menu's to specific groups. This
+addon adds to ways to further limit menu access based on user groups:
+
+* You can block groups to access a specific menu.
+* You can restrict access for a specific group to all menu items except one or more allowed menus.

--- a/base_menu_visibility_restriction/readme/USAGE.md
+++ b/base_menu_visibility_restriction/readme/USAGE.md
@@ -1,9 +1,18 @@
-To use this module, you need to:
+To restrict access to a specific menu item to one or more groups, you need to:
 
 1.  Activate the developer mode
 2.  Go to *Settings \> Technical \> User interface \> Menu Items*.
 3.  Search for any menu and edit it.
 4.  Update "Excluded groups" with one group.
 5.  Login with a user of that group, and you won't see such menu.
+
+To allow access of a specific group to only a specific set of menu items, you need to:
+
+1.  Activate the developer mode
+2.  Go to *Settings \> Technical \> Users & Companies \> Groups*.
+3.  Search for any group and edit it.
+4.  Update "Strict Menu Access" with one or more menus.
+5.  The menu path required to access the configured menu will be added automatically.
+5.  Login with a user of that group, and you will only see those menus.
 
 You can try with demo data for the menu Apps \> App Store and user demo.

--- a/base_menu_visibility_restriction/static/description/index.html
+++ b/base_menu_visibility_restriction/static/description/index.html
@@ -370,9 +370,15 @@ ul.auto-toc {
 !! source digest: sha256:b277c03fb53b079398718103330c847501ece7fe944f8c0532b91434e3e1cc46
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Production/Stable" src="https://img.shields.io/badge/maturity-Production%2FStable-green.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/server-ux/tree/18.0/base_menu_visibility_restriction"><img alt="OCA/server-ux" src="https://img.shields.io/badge/github-OCA%2Fserver--ux-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/server-ux-18-0/server-ux-18-0-base_menu_visibility_restriction"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/server-ux&amp;target_branch=18.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This addon lets you assign “excluded groups” to menu items. If a user
-belongs to a group that is assigned to a menu item as an excluded group,
-the user will not be able to see the menu item.</p>
+<p>This addon lets you apply strict control over which user groups have
+access to which menus. By itself, Odoo let’s you restrict menu’s to
+specific groups. This addon adds to ways to further limit menu access
+based on user groups:</p>
+<ul class="simple">
+<li>You can block groups to access a specific menu.</li>
+<li>You can restrict access for a specific group to all menu items except
+one or more allowed menus.</li>
+</ul>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -388,13 +394,25 @@ the user will not be able to see the menu item.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
-<p>To use this module, you need to:</p>
+<p>To restrict access to a specific menu item to one or more groups, you
+need to:</p>
 <ol class="arabic simple">
 <li>Activate the developer mode</li>
 <li>Go to <em>Settings &gt; Technical &gt; User interface &gt; Menu Items</em>.</li>
 <li>Search for any menu and edit it.</li>
 <li>Update “Excluded groups” with one group.</li>
 <li>Login with a user of that group, and you won’t see such menu.</li>
+</ol>
+<p>To allow access of a specific group to only a specific set of menu
+items, you need to:</p>
+<ol class="arabic simple">
+<li>Activate the developer mode</li>
+<li>Go to <em>Settings &gt; Technical &gt; Users &amp; Companies &gt; Groups</em>.</li>
+<li>Search for any group and edit it.</li>
+<li>Update “Strict Menu Access” with one or more menus.</li>
+<li>The menu path required to access the configured menu will be added
+automatically.</li>
+<li>Login with a user of that group, and you will only see those menus.</li>
 </ol>
 <p>You can try with demo data for the menu Apps &gt; App Store and user demo.</p>
 </div>
@@ -423,6 +441,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li>Dhara Solanki &lt;<a class="reference external" href="mailto:dhara.solanki&#64;initos.com">dhara.solanki&#64;initos.com</a>&gt;</li>
 <li>Nedas Žilinskas &lt;<a class="reference external" href="mailto:nedas.zilinskas&#64;avoin.systems">nedas.zilinskas&#64;avoin.systems</a>&gt;</li>
+<li>Stefan Rijnhart &lt;<a class="reference external" href="mailto:stefan&#64;opener.amsterdam">stefan&#64;opener.amsterdam</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/base_menu_visibility_restriction/tests/test_ir_ui_menu.py
+++ b/base_menu_visibility_restriction/tests/test_ir_ui_menu.py
@@ -5,19 +5,44 @@ from odoo.tests.common import TransactionCase
 
 
 class TestIrUiMenuCase(TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.user_admin = self.browse_ref("base.user_admin").id
-        self.group_hide_menu = self.env["res.groups"].create(
-            {"name": "Hide menu items custom", "users": [(4, self.user_admin)]}
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_admin = cls.env.ref("base.user_admin").id
+        cls.group_hide_menu = cls.env["res.groups"].create(
+            {"name": "Hide menu items custom", "users": [(4, cls.user_admin)]}
         )
-        self.model_ir_uir_menu = self.env["ir.ui.menu"]
-        self.ir_ui_menu = self.browse_ref("base.menu_management")
+        cls.model_ir_ui_menu = cls.env["ir.ui.menu"]
+        cls.menu1 = cls.env.ref("base.menu_management")
+        cls.menu2 = cls.env.ref("base.menu_action_res_users")
+        cls.menu3 = cls.menu2.copy()
 
     def test_ir_ui_menu_admin(self):
-        items = self.model_ir_uir_menu.with_user(self.user_admin)._visible_menu_ids()
-        self.assertTrue(self.ir_ui_menu.id in items)
+        items = self.model_ir_ui_menu.with_user(self.user_admin)._visible_menu_ids()
+        self.assertIn(self.menu1.id, items)
+        self.assertIn(self.menu2.id, items)
+        self.assertIn(self.menu3.id, items)
         # Update ir_ui_menu to assign excluded_group_ids
-        self.ir_ui_menu.write({"excluded_group_ids": [(4, self.group_hide_menu.id)]})
-        items = self.model_ir_uir_menu.with_user(self.user_admin)._visible_menu_ids()
-        self.assertTrue(self.ir_ui_menu.id not in items)
+        self.menu1.write({"excluded_group_ids": [(4, self.group_hide_menu.id)]})
+        items = self.model_ir_ui_menu.with_user(self.user_admin)._visible_menu_ids()
+        self.assertNotIn(self.menu1.id, items)
+        self.assertIn(self.menu2.id, items)
+        self.assertIn(self.menu3.id, items)
+
+        # Now restrict the group to a single menu
+        self.group_hide_menu.included_menu_ids = self.menu2
+        # The parent structure is added automatically
+        self.assertIn(self.menu2.parent_id, self.group_hide_menu.included_menu_ids)
+        self.assertIn(
+            self.menu2.parent_id.parent_id, self.group_hide_menu.included_menu_ids
+        )
+        # Access is now restricted to the configured menu + its parent
+        items = self.model_ir_ui_menu.with_user(self.user_admin)._visible_menu_ids()
+        self.assertEqual(
+            set(items),
+            {
+                self.menu2.parent_id.parent_id.id,
+                self.menu2.parent_id.id,
+                self.menu2.id,
+            },
+        )

--- a/base_menu_visibility_restriction/views/res_groups_views.xml
+++ b/base_menu_visibility_restriction/views/res_groups_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_groups_form" model="ir.ui.view">
+        <field name="inherit_id" ref="base.view_groups_form" />
+        <field name="model">res.groups</field>
+        <field name="priority" eval="199" />
+        <field name="arch" type="xml">
+            <!-- Move the standard menus field into a group to clarify its function -->
+            <page name="menus" position="inside">
+                <group name="odoo_menu_access" string="Standard Odoo Menu Access" />
+            </page>
+            <group name="odoo_menu_access" position="inside">
+                <field name="menu_access" position="move" />
+            </group>
+            <field name="menu_access" position="attributes">
+                <attribute name="nolabel">1</attribute>
+            </field>
+            <group name="odoo_menu_access" position="after">
+                <group name="strict_menu_access" string="Strict Menu Access">
+                    <field name="included_menu_ids" nolabel="1">
+                        <list>
+                            <field name="complete_name" string="Menu" />
+                        </list>
+                    </field>
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
A new configuration option on the group form view allows for another approach to restrict menu access based on group membership. You can restict menu access for a specific group to only those menu items listed on the group.